### PR TITLE
I fixed the Replit configuration and module type.

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -1,0 +1,12 @@
+
+> app@1.0.0 dev
+> vite --host
+
+Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
+Port 5175 is in use, trying another one...
+
+  VITE v7.0.6  ready in 283 ms
+
+  ➜  Local:   http://localhost:5176/
+  ➜  Network: http://192.168.0.2:5176/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite",
     "preview": "vite preview"
   },
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "bugs": {
     "url": "https://github.com/jddnd/business-card-studio/issues"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
+})


### PR DESCRIPTION
This change modifies the package.json to:
- Set the project type to "module" to align with the ES module syntax used in the codebase. This resolves warnings during development.
- Update the "dev" script to include the "--host" flag, allowing the Vite development server to be accessible for previewing in cloud environments like Replit.